### PR TITLE
JDA v4 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,29 +5,29 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.gradle.publish:plugin-publish-plugin:0.9.7'
+    classpath 'com.gradle.publish:plugin-publish-plugin:0.10.1'
   }
 }
 
 plugins {
   id 'java-gradle-plugin'
   id 'maven-publish'
-  id 'com.jfrog.bintray' version '1.7.3'
+  id 'com.jfrog.bintray' version '1.8.4'
 }
 
 apply plugin: 'com.gradle.plugin-publish'
 
 group 'com.sedmelluq'
 ext.moduleName = 'jdaction'
-version = '1.0.2'
+version = '1.0.3'
 
 repositories {
   jcenter()
 }
 
 dependencies {
-  compile gradleApi()
-  compile 'org.ow2.asm:asm-debug-all:5.0.3'
+  implementation gradleApi()
+  implementation 'org.ow2.asm:asm-debug-all:6.0_BETA'
 }
 
 gradlePlugin {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Tue Dec 20 23:58:45 EET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip

--- a/src/main/java/com/sedmelluq/discord/jdaction/NoActionPlugin.java
+++ b/src/main/java/com/sedmelluq/discord/jdaction/NoActionPlugin.java
@@ -1,7 +1,7 @@
 package com.sedmelluq.discord.jdaction;
 
 import org.gradle.api.Project;
-import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.plugins.quality.CodeQualityExtension;
@@ -22,6 +22,11 @@ public class NoActionPlugin extends AbstractCodeQualityPlugin<NoActionVerificati
   }
 
   @Override
+  protected void configureConfiguration(Configuration configuration) {
+
+  }
+
+  @Override
   protected CodeQualityExtension createExtension() {
     extension = project.getExtensions().create("jdaction", Extension.class, project);
     return extension;
@@ -32,16 +37,8 @@ public class NoActionPlugin extends AbstractCodeQualityPlugin<NoActionVerificati
     task.setSource(sourceSet.getAllJava());
 
     ConventionMapping taskMapping = task.getConventionMapping();
-    taskMapping.map("classes", new Callable<FileCollection>() {
-      @Override
-      public FileCollection call() {
-        return project.fileTree(sourceSet.getOutput().getClassesDir()).builtBy(sourceSet.getOutput());
-      }
-    });
-
-    for (Task classesTask : project.getTasksByName(sourceSet.getClassesTaskName(), false)) {
-      classesTask.finalizedBy(task.getPath());
-    }
+    taskMapping.map("classes", (Callable<FileCollection>) () -> project.fileTree(sourceSet.getOutput().getClassesDirs()).builtBy(sourceSet.getOutput()));
+    project.getTasksByName(sourceSet.getClassesTaskName(), false).forEach(classesTask -> classesTask.finalizedBy(task.getPath()));
   }
 
   public static class Extension extends CodeQualityExtension {

--- a/src/main/java/com/sedmelluq/discord/jdaction/NoActionTargetDetector.java
+++ b/src/main/java/com/sedmelluq/discord/jdaction/NoActionTargetDetector.java
@@ -8,7 +8,7 @@ public class NoActionTargetDetector {
   );
 
   public static boolean isRestActionDescriptor(String descriptor) {
-    if (descriptor.endsWith(")Lnet/dv8tion/jda/core/requests/RestAction;")) {
+    if (descriptor.endsWith(")Lnet/dv8tion/jda/api/requests/RestAction;")) {
       return true;
     }
 


### PR DESCRIPTION
As written in the title, this PR introduces support for JDA v4 and also updates gradle, plugins and gets rid of deprecated `compile`.